### PR TITLE
fix setup modal

### DIFF
--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -411,12 +411,25 @@ function createSetupModal(channelInfo, existingChannel, userTimezone = 'UTC') {
   const isUpdate = !!existingChannel;
   const config = existingChannel?.config || {};
 
-  // Determine the timezone with priority
-  const defaultTimezone = config.timezone || userTimezone || 'UTC';
+  let defaultTimezone;
+  
+  if (isUpdate) {
+    // When UPDATE - use existing channel configuration
+    defaultTimezone = config.timezone || userTimezone || 'UTC';
+  } else {
+    // When CREATE - ALWAYS use auto-detected user timezone
+    defaultTimezone = userTimezone || 'UTC';
+  }
+  
   const supportedTimezone = TIMEZONES.find(tz => tz.value === defaultTimezone);
   const selectedTimezone = supportedTimezone ? defaultTimezone : 'UTC';
 
-  return {
+  // ✅ Correct message
+  const timezoneHint = isUpdate 
+    ? `Current timezone: *${selectedTimezone}*`
+    : `Auto-detected timezone: *${selectedTimezone}* ${selectedTimezone !== userTimezone ? '(adjusted to supported timezone)' : ''}`;
+
+  return  {
     type: 'modal',
     callback_id: BLOCK_IDS.SETUP_MODAL,
     title: {
@@ -445,7 +458,7 @@ function createSetupModal(channelInfo, existingChannel, userTimezone = 'UTC') {
         elements: [
           {
             type: 'mrkdwn',
-            text: `🌍 Auto-detected timezone: *${selectedTimezone}* ${selectedTimezone !== userTimezone ? '(adjusted to supported timezone)' : ''}`
+            text: `🌍 ${timezoneHint}`
           }
         ]
       },
@@ -571,7 +584,7 @@ function createSetupModal(channelInfo, existingChannel, userTimezone = 'UTC') {
               type: 'plain_text',
               text: TIMEZONES.find(tz => tz.value === selectedTimezone)?.label || 'UTC'
             },
-            value: selectedTimezone
+            value: selectedTimezone // ✅ Use correct timezone!
           },
           options: TIMEZONES.map(tz => ({
             text: {

--- a/handlers/views.js
+++ b/handlers/views.js
@@ -173,7 +173,9 @@ function validateSetupForm(values) {
     const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
     const daysText = days.map(day => dayNames[day]).join(', ');
   
-    const timezone = userTimezone;
+    // ✅ MAIN FIX: Use selected timezone from form!
+    const selectedTimezone = values[BLOCK_IDS.TIMEZONE_SELECT]?.[BLOCK_IDS.TIMEZONE_SELECT]?.selected_option?.value;
+    const timezone = selectedTimezone || userTimezone || 'UTC';
   
     // Extract participants (optional)
     const participantsData = values[BLOCK_IDS.PARTICIPANTS_SELECT]?.[BLOCK_IDS.PARTICIPANTS_SELECT];
@@ -184,7 +186,7 @@ function validateSetupForm(values) {
       time,
       days,
       daysText,
-      timezone,
+      timezone, // ✅ Now this is the SELECTED timezone, not userTimezone!
       participants
     };
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a contextual timezone hint in the setup modal, displaying either the current or auto-detected timezone, with additional notes if adjustments were made.
- **Bug Fixes**
  - Improved timezone selection logic to prioritize the user's explicit selection in forms, ensuring the correct timezone is saved and displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->